### PR TITLE
feat: add automated backup script for lscs-core

### DIFF
--- a/scripts/backups/README.md
+++ b/scripts/backups/README.md
@@ -10,7 +10,24 @@ Generally, backup the following resources:
 
 ## LSCS Core Backup Documentation
 
-docs here
+### Applications Affected
+* `core.app.dlsu-lscs.org`
+
+### Purpose
+* Automates database SQL dumps and environment variable backups.
+* Designed specifically for Dokploy-managed Docker containers.
+* Environment-aware: Works seamlessly on both Development (`lscsdev1`) and Deployment (`lscsprod1`) servers.
+
+### Workflow / Steps
+1. **Environment Check:** Detects the current server environment (deployment or development) based on the hostname.
+2. **Container Identification:** Fetches the dynamic container IDs for the database and API based on their static base names.
+3. **Directory Prep:** Creates a dedicated backup folder (`./backup/lscs-core`) if it does not already exist.
+4. **Database Backup:** Executes an internal `mysqldump` command via `docker exec` to output an SQL file (`sql_backup.sql`).
+5. **Environment Variables Backup:** Outputs a copy of the API's current environment variables. If a previous backup (`env_backup.env`) exists, it compares the current version to the previous version and appends only the newly added variables.
+
+### ⚠️ Important Notes
+* **Manual Execution:** This script does not currently run on an automated schedule. It must be executed manually via the terminal: `./your_script_name.sh`
+* **Disaster Recovery:** Instructions on how to restore from these backup files re currently pending. (Awaiting @ej's approval to finalize the recovery protocol).
 
 ---
 

--- a/scripts/backups/backup_lscs_core.sh
+++ b/scripts/backups/backup_lscs_core.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Get current server
+CURRENT_SERVER=$(hostname)
+
+if [ "$CURRENT_SERVER" == "lscsprod1.dlsu-lscs.org" ]; then
+   DB_CONTAINER_NAME="lscs-core-db"
+   API_CONTAINER_NAME="lscs-core-api"	
+elif [ "$CURRENT_SERVER" == "lscsdev1.dlsu-lscs.org" ]; then
+   DB_CONTAINER_NAME="lscs-core-database-dev"
+   API_CONTAINER_NAME="lscs-core-dev-api"
+else
+  echo "Currently in an unknown server.";
+  exit 1;
+fi
+
+# Get the container IDs
+DB_ID=$(docker ps -q -f "name=$DB_CONTAINER_NAME")
+API_ID=$(docker ps -q -f "name=$API_CONTAINER_NAME")
+
+# Safety Check: Make sure the containers are actually running
+if [ -z "$DB_ID" ] || [ -z "$API_ID" ]; then
+    echo "Error: Could not find one or both Dokploy containers. Backup aborted."
+    exit 1
+fi
+
+DB_PASSWORD=$(docker exec "$DB_ID" printenv MYSQL_ROOT_PASSWORD)
+DB_NAME=$(docker exec "$DB_ID" printenv MYSQL_DATABASE)
+
+# Create a backup folder
+mkdir -p ./backup/lscs-core
+
+# Run a database dump that outputs a file [Database]
+docker exec "$DB_ID" /usr/bin/mysqldump -u root --password="$DB_PASSWORD" "$DB_NAME" > ./backup/lscs-core/sql_backup.sql
+echo "Database dump successfully created."
+
+# Copy environment variables to a .env [LSCS Core API]
+# Check if there is an existing backup file
+if [ ! -f "./backup/lscs-core/env_backup.env" ]; then
+   docker exec "$API_ID" printenv > "./backup/lscs-core/env_backup.env"
+   echo "Initial environment variables backup created."
+else
+   docker exec "$API_ID" printenv > "./backup/lscs-core/env_backup_temp.env"
+   grep -Fxvf "./backup/lscs-core/env_backup.env" "./backup/lscs-core/env_backup_temp.env" >> "./backup/lscs-core/env_backup.env"
+   rm -f "./backup/lscs-core/env_backup_temp.env"
+   echo "New variables (if any) are appended to the env backup file."
+fi


### PR DESCRIPTION
#2 

Created a bash script to automate backups for the LSCS Core database and environment variables.

Steps:
1. Validates whether the script is running on the Development or Production server via hostname.
2. Fetches the dynamic Docker container IDs using partial name matching.
3. Creates the target backup directories if they don't exist.
4. Executes a database dump and saves it to a .sql file.
5. Copies the API environment variables, checking for previous backups and appending only the newly added variables to prevent overwriting.

@ejsadiarin please check for errors and feedback ^^
 